### PR TITLE
Remove weird char at the beginning of the file

### DIFF
--- a/audit.sql
+++ b/audit.sql
@@ -1,4 +1,4 @@
-﻿-- An audit history is important on most tables. Provide an audit trigger that logs to
+-- An audit history is important on most tables. Provide an audit trigger that logs to
 -- a dedicated audit table for the major relations.
 --
 -- This file should be generic and not depend on application roles or structures,


### PR DESCRIPTION
It seems to be a `ZERO WIDTH NO-BREAK SPACE` displayed as `<U+FEFF>` in git diff.
I can lead to an error while using the SQL from QGIS or python